### PR TITLE
webserver_name moved to variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
 # Pass in a comma-separated list of repos to use (e.g. "remi,epel").
 php_enablerepo: ""
+# empty string not to restart any webserver
+webserver_name: webserver
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,4 +3,3 @@
 php_enablerepo: ""
 # empty string not to restart any webserver
 webserver_name: webserver
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
     state: present
     enablerepo: "{{ php_enablerepo | default(omit, true) }}"
   notify:
-    - restart webserver
+    - restart "{{webserver_name}}"
     - restart php-fpm
   when: ansible_os_family == 'RedHat'
 
@@ -24,6 +24,6 @@
     name: "{{ php_mysql_package }}"
     state: present
   notify:
-    - restart webserver
+    - restart "{{webserver_name}}"
     - restart php-fpm
   when: ansible_os_family == 'Debian'


### PR DESCRIPTION
This change allows support of restarting webserver that is not aliased as `webserver` in systemd or not restarting any webserver at all - which is usable when php works in CGI mode.